### PR TITLE
Added predeployed vehicles

### DIFF
--- a/public/co61_AW_I&A_TFTEdit.Altis/mission.sqm
+++ b/public/co61_AW_I&A_TFTEdit.Altis/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1;
 	class ItemIDProvider
 	{
-		nextID=680;
+		nextID=689;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={14641.671,80.771187,16751.314};
-		dir[]={-0.23055701,-0.94543058,0.23029545};
-		up[]={-0.66890776,0.32579222,0.66814965};
-		aside[]={0.7067194,1.5809201e-007,0.70751965};
+		pos[]={26800.791,61.724037,24621.336};
+		dir[]={-0.77192903,-0.52131385,-0.36381522};
+		up[]={-0.47156432,0.85336429,-0.22225149};
+		aside[]={-0.42632958,4.4936314e-008,0.90456957};
 	};
 };
 binarizationWanted=0;
@@ -327,7 +327,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=555;
+		items=554;
 		class Item0
 		{
 			dataType="Marker";
@@ -1095,15 +1095,15 @@ class Mission
 		class Item84
 		{
 			dataType="Marker";
-			position[]={23376.975,12.849569,19802.217};
+			position[]={23376.975,3.1552963e+038,19802.217};
 			name="vehService_1";
-			text="Vehicle Service";
+			text="Vehicle Depot";
 			type="b_maint";
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
-			angle=0.2292757;
 			id=84;
+			atlOffset=3.1552963e+038;
 		};
 		class Item85
 		{
@@ -1120,14 +1120,15 @@ class Mission
 		class Item86
 		{
 			dataType="Marker";
-			position[]={19958.486,60.28656,11448.795};
+			position[]={19958.486,3.0323427e+038,11448.795};
 			name="vehService_3";
-			text="Vehicle Service";
+			text="Vehicle Depot";
 			type="b_maint";
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
 			id=86;
+			atlOffset=3.0323427e+038;
 		};
 		class Item87
 		{
@@ -1530,62 +1531,30 @@ class Mission
 		class Item126
 		{
 			dataType="Marker";
-			position[]={6094.3848,217.34969,20366.492};
-			name="Chalkeia_1";
-			type="Empty";
-			id=126;
+			position[]={5767.9648,-1.3939218e-017,20091.301};
+			name="vehService_4";
+			text="Vehicle Depot";
+			type="b_maint";
+			colorName="ColorGrey";
+			a=0.5;
+			b=0.5;
+			id=127;
+			atlOffset=-221.97894;
 		};
 		class Item127
 		{
 			dataType="Marker";
-			position[]={5767.9648,221.97894,20091.301};
-			name="vehService_4";
-			text="Vehicle Service";
+			position[]={5021.373,3.15902e+034,14433.188};
+			name="vehService_5";
+			text="Vehicle Depot";
 			type="b_maint";
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
-			angle=302.88394;
-			id=127;
+			id=130;
+			atlOffset=3.15902e+034;
 		};
 		class Item128
-		{
-			dataType="Marker";
-			position[]={5105.8994,16.763834,14452.836};
-			name="Dump_1";
-			type="Empty";
-			id=128;
-		};
-		class Item129
-		{
-			dataType="Marker";
-			position[]={5342.9023,18.750324,14733.253};
-			name="Chalkeia_1_1";
-			type="Empty";
-			id=129;
-		};
-		class Item130
-		{
-			dataType="Marker";
-			position[]={5021.3726,16.924837,14433.188};
-			name="vehService_5";
-			text="Vehicle Service";
-			type="b_maint";
-			colorName="ColorGrey";
-			a=0.5;
-			b=0.5;
-			angle=274.3526;
-			id=130;
-		};
-		class Item131
-		{
-			dataType="Marker";
-			position[]={12936.356,43.497898,20142.49};
-			name="Chalkeia_2";
-			type="Empty";
-			id=131;
-		};
-		class Item132
 		{
 			dataType="Marker";
 			position[]={12616.097,51.967915,19887.016};
@@ -1595,10 +1564,9 @@ class Mission
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
-			angle=351.01904;
 			id=132;
 		};
-		class Item133
+		class Item129
 		{
 			dataType="Marker";
 			position[]={11822.401,12.562449,14150.526};
@@ -1608,28 +1576,10 @@ class Mission
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
-			angle=325.21472;
 			id=133;
 			atlOffset=9.5367432e-007;
 		};
-		class Item134
-		{
-			dataType="Marker";
-			position[]={15700.336,0.0002601684,14544.311};
-			name="Alikampos_1";
-			type="Empty";
-			id=134;
-			atlOffset=70.226974;
-		};
-		class Item135
-		{
-			dataType="Marker";
-			position[]={21297.623,25.462379,17035.467};
-			name="Neochori_1";
-			type="Empty";
-			id=135;
-		};
-		class Item136
+		class Item130
 		{
 			dataType="Marker";
 			position[]={20783.91,37.098419,16671.77};
@@ -1639,74 +1589,48 @@ class Mission
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
-			angle=67.828163;
 			id=136;
 		};
-		class Item137
+		class Item131
 		{
 			dataType="Marker";
-			position[]={21243.592,21.902754,7137.605};
+			position[]={21243.592,-2.8777896e-021,7137.605};
 			name="vehService_9";
-			text="Vehicle Service";
+			text="Vehicle Depot";
 			type="b_maint";
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
-			angle=30.526184;
 			id=137;
+			atlOffset=-21.902754;
 		};
-		class Item138
+		class Item132
 		{
 			dataType="Marker";
-			position[]={8156.501,86.685699,11685.059};
-			name="Feres_1";
-			type="Empty";
-			id=138;
-		};
-		class Item139
-		{
-			dataType="Marker";
-			position[]={6553.8213,2.3483954e-005,10800.431};
-			name="Selakano Outpost_1";
-			type="Empty";
-			id=139;
-			atlOffset=3.1934168;
-		};
-		class Item140
-		{
-			dataType="Marker";
-			position[]={7328.5342,13.271528,11353.838};
-			name="airfield4_1";
-			type="Empty";
-			id=140;
-		};
-		class Item141
-		{
-			dataType="Marker";
-			position[]={7256.834,6.3651772,11111.93};
+			position[]={7256.834,-3.3405733e-038,11111.93};
 			name="vehService_10";
-			text="Vehicle Service";
+			text="Vehicle Depot";
 			type="b_maint";
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
-			angle=239.45593;
 			id=141;
+			atlOffset=-6.3651772;
 		};
-		class Item142
+		class Item133
 		{
 			dataType="Marker";
-			position[]={26727.711,22.330521,24554.17};
-			name="vehService_1_1";
-			text="Vehicle Service";
+			position[]={26727.711,3.1032909e+034,24554.17};
+			name="vehService_11";
+			text="Vehicle Depot";
 			type="b_maint";
 			colorName="ColorGrey";
 			a=0.5;
 			b=0.5;
-			angle=261.13089;
 			id=142;
+			atlOffset=3.1032909e+034;
 		};
-		class Item143
+		class Item134
 		{
 			dataType="Marker";
 			position[]={9225.2188,16.618668,21583.357};
@@ -1719,7 +1643,7 @@ class Mission
 			angle=7.4665551;
 			id=143;
 		};
-		class Item144
+		class Item135
 		{
 			dataType="Marker";
 			position[]={27126.063,24.700859,24925.852};
@@ -1731,7 +1655,7 @@ class Mission
 			b=0.5;
 			id=144;
 		};
-		class Item145
+		class Item136
 		{
 			dataType="Marker";
 			position[]={21047.311,26.049686,7144.145};
@@ -1744,7 +1668,7 @@ class Mission
 			angle=330.72256;
 			id=145;
 		};
-		class Item146
+		class Item137
 		{
 			dataType="Trigger";
 			position[]={-256.8938,-0.092763841,658.35046};
@@ -1763,7 +1687,7 @@ class Mission
 			type="EmptyDetector";
 			atlOffset=185.87724;
 		};
-		class Item147
+		class Item138
 		{
 			dataType="Trigger";
 			position[]={11577.894,23.213652,11907.802};
@@ -1780,7 +1704,7 @@ class Mission
 			id=147;
 			type="EmptyDetector";
 		};
-		class Item148
+		class Item139
 		{
 			dataType="Trigger";
 			position[]={14610.348,17.91,16627.117};
@@ -1797,7 +1721,7 @@ class Mission
 			id=148;
 			type="EmptyDetector";
 		};
-		class Item149
+		class Item140
 		{
 			dataType="Trigger";
 			position[]={14564.659,17.91,16822.17};
@@ -1816,7 +1740,7 @@ class Mission
 			id=149;
 			type="EmptyDetector";
 		};
-		class Item150
+		class Item141
 		{
 			dataType="Trigger";
 			position[]={15176.263,17.91,16813.779};
@@ -1833,7 +1757,7 @@ class Mission
 			id=150;
 			type="EmptyDetector";
 		};
-		class Item151
+		class Item142
 		{
 			dataType="Trigger";
 			position[]={9024.2236,111.7303,15724.93};
@@ -1852,7 +1776,7 @@ class Mission
 			id=151;
 			type="EmptyDetector";
 		};
-		class Item152
+		class Item143
 		{
 			dataType="Trigger";
 			position[]={23376.957,12.850264,19802.096};
@@ -1871,7 +1795,7 @@ class Mission
 			id=152;
 			type="EmptyDetector";
 		};
-		class Item153
+		class Item144
 		{
 			dataType="Trigger";
 			position[]={19958.604,60.283524,11448.754};
@@ -1890,7 +1814,7 @@ class Mission
 			id=153;
 			type="EmptyDetector";
 		};
-		class Item154
+		class Item145
 		{
 			dataType="Trigger";
 			position[]={5768.0503,221.96765,20091.461};
@@ -1909,7 +1833,7 @@ class Mission
 			id=154;
 			type="EmptyDetector";
 		};
-		class Item155
+		class Item146
 		{
 			dataType="Trigger";
 			position[]={5021.395,16.924807,14433.322};
@@ -1928,7 +1852,7 @@ class Mission
 			id=155;
 			type="EmptyDetector";
 		};
-		class Item156
+		class Item147
 		{
 			dataType="Trigger";
 			position[]={12616.243,51.961075,19886.938};
@@ -1947,7 +1871,7 @@ class Mission
 			id=156;
 			type="EmptyDetector";
 		};
-		class Item157
+		class Item148
 		{
 			dataType="Trigger";
 			position[]={11822.556,12.561558,14150.553};
@@ -1966,7 +1890,7 @@ class Mission
 			id=157;
 			type="EmptyDetector";
 		};
-		class Item158
+		class Item149
 		{
 			dataType="Trigger";
 			position[]={20783.912,37.100311,16671.627};
@@ -1985,7 +1909,7 @@ class Mission
 			id=158;
 			type="EmptyDetector";
 		};
-		class Item159
+		class Item150
 		{
 			dataType="Trigger";
 			position[]={21243.73,21.901779,7137.5479};
@@ -2004,7 +1928,7 @@ class Mission
 			id=159;
 			type="EmptyDetector";
 		};
-		class Item160
+		class Item151
 		{
 			dataType="Trigger";
 			position[]={7256.7905,6.3707314,11112.067};
@@ -2023,7 +1947,7 @@ class Mission
 			id=160;
 			type="EmptyDetector";
 		};
-		class Item161
+		class Item152
 		{
 			dataType="Trigger";
 			position[]={26727.828,22.332361,24554.158};
@@ -2042,7 +1966,7 @@ class Mission
 			id=161;
 			type="EmptyDetector";
 		};
-		class Item162
+		class Item153
 		{
 			dataType="Trigger";
 			position[]={9225.1533,16.619883,21583.211};
@@ -2060,7 +1984,7 @@ class Mission
 			id=162;
 			type="EmptyDetector";
 		};
-		class Item163
+		class Item154
 		{
 			dataType="Trigger";
 			position[]={27126.023,24.700321,24925.689};
@@ -2077,7 +2001,7 @@ class Mission
 			id=163;
 			type="EmptyDetector";
 		};
-		class Item164
+		class Item155
 		{
 			dataType="Trigger";
 			position[]={21047.361,26.04734,7143.9883};
@@ -2095,7 +2019,7 @@ class Mission
 			id=164;
 			type="EmptyDetector";
 		};
-		class Item165
+		class Item156
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2113,7 +2037,7 @@ class Mission
 			id=166;
 			type="B_Truck_01_medical_F";
 		};
-		class Item166
+		class Item157
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2154,7 +2078,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item167
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2197,7 +2121,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item168
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2239,7 +2163,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item169
+		class Item160
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2282,7 +2206,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item170
+		class Item161
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2325,7 +2249,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item171
+		class Item162
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2368,7 +2292,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item172
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2408,7 +2332,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item173
+		class Item164
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2426,7 +2350,7 @@ class Mission
 			id=175;
 			type="B_Quadbike_01_F";
 		};
-		class Item174
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2445,7 +2369,7 @@ class Mission
 			id=176;
 			type="B_Quadbike_01_F";
 		};
-		class Item175
+		class Item166
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2464,7 +2388,7 @@ class Mission
 			id=177;
 			type="B_Quadbike_01_F";
 		};
-		class Item176
+		class Item167
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2482,7 +2406,7 @@ class Mission
 			id=178;
 			type="B_Quadbike_01_F";
 		};
-		class Item177
+		class Item168
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2500,7 +2424,7 @@ class Mission
 			type="B_Boat_Armed_01_minigun_F";
 			atlOffset=5.8539639;
 		};
-		class Item178
+		class Item169
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2518,7 +2442,7 @@ class Mission
 			type="B_Boat_Armed_01_minigun_F";
 			atlOffset=9.1192045;
 		};
-		class Item179
+		class Item170
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2536,7 +2460,7 @@ class Mission
 			type="B_SDV_01_F";
 			atlOffset=9.3134584;
 		};
-		class Item180
+		class Item171
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2555,7 +2479,7 @@ class Mission
 			id=182;
 			type="B_supplyCrate_F";
 		};
-		class Item181
+		class Item172
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2598,7 +2522,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item182
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2640,7 +2564,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item183
+		class Item174
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2683,7 +2607,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item184
+		class Item175
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2725,7 +2649,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item185
+		class Item176
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2768,7 +2692,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item186
+		class Item177
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2781,13 +2705,13 @@ class Mission
 			{
 				skill=0.60000002;
 				lock="UNLOCKED";
-				init="_nil = [this, 480, 480] execVM ""veh_respawn.sqf""";
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
 			};
 			id=188;
 			type="B_APC_Wheeled_01_cannon_F";
 			atlOffset=0.5;
 		};
-		class Item187
+		class Item178
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2806,7 +2730,7 @@ class Mission
 			id=189;
 			type="B_Truck_01_Repair_F";
 		};
-		class Item188
+		class Item179
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2824,7 +2748,7 @@ class Mission
 			id=190;
 			type="B_APC_Tracked_01_CRV_F";
 		};
-		class Item189
+		class Item180
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2845,7 +2769,7 @@ class Mission
 			id=191;
 			type="B_Heli_Transport_03_F";
 		};
-		class Item190
+		class Item181
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2866,7 +2790,7 @@ class Mission
 			id=192;
 			type="B_Heli_Light_01_F";
 		};
-		class Item191
+		class Item182
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2886,7 +2810,7 @@ class Mission
 			id=193;
 			type="B_Heli_Transport_01_F";
 		};
-		class Item192
+		class Item183
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2905,7 +2829,7 @@ class Mission
 			id=194;
 			type="B_Truck_01_fuel_F";
 		};
-		class Item193
+		class Item184
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2923,7 +2847,7 @@ class Mission
 			id=195;
 			type="B_Truck_01_ammo_F";
 		};
-		class Item194
+		class Item185
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2940,7 +2864,7 @@ class Mission
 			id=196;
 			type="Land_HelipadSquare_F";
 		};
-		class Item195
+		class Item186
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2958,7 +2882,7 @@ class Mission
 			id=197;
 			type="Land_HelipadSquare_F";
 		};
-		class Item196
+		class Item187
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2975,7 +2899,7 @@ class Mission
 			id=198;
 			type="Land_HelipadCivil_F";
 		};
-		class Item197
+		class Item188
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2992,7 +2916,7 @@ class Mission
 			id=199;
 			type="Land_HelipadCivil_F";
 		};
-		class Item198
+		class Item189
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3009,7 +2933,7 @@ class Mission
 			id=200;
 			type="Land_HelipadCivil_F";
 		};
-		class Item199
+		class Item190
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3026,7 +2950,7 @@ class Mission
 			id=201;
 			type="Land_HelipadCivil_F";
 		};
-		class Item200
+		class Item191
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3043,7 +2967,7 @@ class Mission
 			id=202;
 			type="Land_HelipadCivil_F";
 		};
-		class Item201
+		class Item192
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3084,7 +3008,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item202
+		class Item193
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3125,7 +3049,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item203
+		class Item194
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3166,7 +3090,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item204
+		class Item195
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3178,13 +3102,13 @@ class Mission
 			class Attributes
 			{
 				skill=0.60000002;
-				init="_nil = [this, 480, 480] execVM ""veh_respawn.sqf""";
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
 			};
 			id=209;
 			type="B_MBT_01_TUSK_F";
 			atlOffset=0.5;
 		};
-		class Item205
+		class Item196
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3200,7 +3124,7 @@ class Mission
 			id=211;
 			type="RoadCone_F";
 		};
-		class Item206
+		class Item197
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3216,7 +3140,7 @@ class Mission
 			id=212;
 			type="RoadCone_F";
 		};
-		class Item207
+		class Item198
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3232,7 +3156,7 @@ class Mission
 			id=213;
 			type="RoadCone_F";
 		};
-		class Item208
+		class Item199
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3248,7 +3172,7 @@ class Mission
 			id=214;
 			type="RoadCone_F";
 		};
-		class Item209
+		class Item200
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3266,7 +3190,7 @@ class Mission
 			id=215;
 			type="RoadCone_F";
 		};
-		class Item210
+		class Item201
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3284,7 +3208,7 @@ class Mission
 			id=216;
 			type="RoadCone_F";
 		};
-		class Item211
+		class Item202
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3302,7 +3226,7 @@ class Mission
 			id=217;
 			type="RoadCone_F";
 		};
-		class Item212
+		class Item203
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3320,7 +3244,7 @@ class Mission
 			id=218;
 			type="RoadCone_F";
 		};
-		class Item213
+		class Item204
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3360,7 +3284,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item214
+		class Item205
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3377,7 +3301,7 @@ class Mission
 			id=220;
 			type="RoadCone_F";
 		};
-		class Item215
+		class Item206
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3417,7 +3341,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item216
+		class Item207
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3434,7 +3358,7 @@ class Mission
 			id=222;
 			type="RoadCone_F";
 		};
-		class Item217
+		class Item208
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3453,7 +3377,7 @@ class Mission
 			type="RoadCone_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item218
+		class Item209
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3471,7 +3395,7 @@ class Mission
 			id=228;
 			type="RoadCone_F";
 		};
-		class Item219
+		class Item210
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3489,7 +3413,7 @@ class Mission
 			id=229;
 			type="RoadCone_F";
 		};
-		class Item220
+		class Item211
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3507,7 +3431,7 @@ class Mission
 			id=230;
 			type="RoadCone_F";
 		};
-		class Item221
+		class Item212
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3525,7 +3449,7 @@ class Mission
 			id=231;
 			type="RoadCone_F";
 		};
-		class Item222
+		class Item213
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3544,7 +3468,7 @@ class Mission
 			type="RoadCone_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item223
+		class Item214
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3562,7 +3486,7 @@ class Mission
 			id=233;
 			type="RoadCone_F";
 		};
-		class Item224
+		class Item215
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3580,7 +3504,7 @@ class Mission
 			id=236;
 			type="RoadCone_F";
 		};
-		class Item225
+		class Item216
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3598,7 +3522,7 @@ class Mission
 			id=237;
 			type="RoadCone_F";
 		};
-		class Item226
+		class Item217
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3616,7 +3540,7 @@ class Mission
 			id=238;
 			type="RoadCone_F";
 		};
-		class Item227
+		class Item218
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3634,7 +3558,7 @@ class Mission
 			id=239;
 			type="RoadCone_F";
 		};
-		class Item228
+		class Item219
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3652,7 +3576,7 @@ class Mission
 			id=240;
 			type="RoadCone_F";
 		};
-		class Item229
+		class Item220
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3670,7 +3594,7 @@ class Mission
 			id=241;
 			type="RoadCone_F";
 		};
-		class Item230
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3688,7 +3612,7 @@ class Mission
 			id=242;
 			type="RoadCone_F";
 		};
-		class Item231
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3706,7 +3630,7 @@ class Mission
 			id=243;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item232
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3725,7 +3649,7 @@ class Mission
 			id=244;
 			type="I_Heli_light_03_F";
 		};
-		class Item233
+		class Item224
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3744,7 +3668,7 @@ class Mission
 			id=245;
 			type="B_Heli_Light_01_F";
 		};
-		class Item234
+		class Item225
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3764,7 +3688,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.0048408508;
 		};
-		class Item235
+		class Item226
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3784,7 +3708,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.038669586;
 		};
-		class Item236
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3804,7 +3728,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.00016784668;
 		};
-		class Item237
+		class Item228
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3824,7 +3748,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.0045151711;
 		};
-		class Item238
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3843,7 +3767,7 @@ class Mission
 			type="Land_PaperBox_open_full_F";
 			atlOffset=186.01643;
 		};
-		class Item239
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3862,7 +3786,7 @@ class Mission
 			type="Land_PaperBox_closed_F";
 			atlOffset=186.02745;
 		};
-		class Item240
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3905,7 +3829,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item241
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3948,7 +3872,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item242
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3991,7 +3915,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item243
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4033,7 +3957,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item244
+		class Item235
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4076,7 +4000,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item245
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4119,7 +4043,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item246
+		class Item237
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4162,7 +4086,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item247
+		class Item238
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4204,7 +4128,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item248
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4246,7 +4170,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item249
+		class Item240
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4288,7 +4212,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item250
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4330,7 +4254,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item251
+		class Item242
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4372,7 +4296,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item252
+		class Item243
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4414,7 +4338,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item253
+		class Item244
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4456,7 +4380,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item254
+		class Item245
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4498,7 +4422,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item255
+		class Item246
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4540,7 +4464,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item256
+		class Item247
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4582,7 +4506,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item257
+		class Item248
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4624,7 +4548,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item258
+		class Item249
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4666,7 +4590,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item259
+		class Item250
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4683,7 +4607,7 @@ class Mission
 			id=271;
 			type="Land_HelipadCivil_F";
 		};
-		class Item260
+		class Item251
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4700,7 +4624,7 @@ class Mission
 			id=272;
 			type="Land_runway_edgelight_blue_F";
 		};
-		class Item261
+		class Item252
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4717,7 +4641,7 @@ class Mission
 			id=273;
 			type="Land_runway_edgelight_blue_F";
 		};
-		class Item262
+		class Item253
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4734,7 +4658,7 @@ class Mission
 			id=274;
 			type="Land_runway_edgelight_blue_F";
 		};
-		class Item263
+		class Item254
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4751,7 +4675,7 @@ class Mission
 			id=275;
 			type="Land_runway_edgelight_blue_F";
 		};
-		class Item264
+		class Item255
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4768,7 +4692,7 @@ class Mission
 			id=276;
 			type="Land_HelipadCivil_F";
 		};
-		class Item265
+		class Item256
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4785,7 +4709,7 @@ class Mission
 			id=277;
 			type="Land_runway_edgelight_blue_F";
 		};
-		class Item266
+		class Item257
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4802,7 +4726,7 @@ class Mission
 			id=278;
 			type="Land_runway_edgelight_blue_F";
 		};
-		class Item267
+		class Item258
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4819,7 +4743,7 @@ class Mission
 			id=279;
 			type="Land_runway_edgelight_blue_F";
 		};
-		class Item268
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4836,7 +4760,7 @@ class Mission
 			id=280;
 			type="Land_runway_edgelight_blue_F";
 		};
-		class Item269
+		class Item260
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4852,7 +4776,7 @@ class Mission
 			id=281;
 			type="RoadCone_F";
 		};
-		class Item270
+		class Item261
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4868,7 +4792,7 @@ class Mission
 			id=282;
 			type="RoadCone_F";
 		};
-		class Item271
+		class Item262
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4884,7 +4808,7 @@ class Mission
 			id=283;
 			type="RoadCone_F";
 		};
-		class Item272
+		class Item263
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4900,7 +4824,7 @@ class Mission
 			id=284;
 			type="RoadCone_F";
 		};
-		class Item273
+		class Item264
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4941,7 +4865,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item274
+		class Item265
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4982,7 +4906,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item275
+		class Item266
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5024,7 +4948,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item276
+		class Item267
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5066,7 +4990,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item277
+		class Item268
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5082,7 +5006,7 @@ class Mission
 			id=289;
 			type="RoadCone_F";
 		};
-		class Item278
+		class Item269
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5098,7 +5022,7 @@ class Mission
 			id=290;
 			type="RoadCone_F";
 		};
-		class Item279
+		class Item270
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5114,7 +5038,7 @@ class Mission
 			id=291;
 			type="RoadCone_F";
 		};
-		class Item280
+		class Item271
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5130,7 +5054,7 @@ class Mission
 			id=292;
 			type="RoadCone_F";
 		};
-		class Item281
+		class Item272
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5146,7 +5070,7 @@ class Mission
 			id=293;
 			type="RoadCone_F";
 		};
-		class Item282
+		class Item273
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5162,7 +5086,7 @@ class Mission
 			id=294;
 			type="RoadCone_F";
 		};
-		class Item283
+		class Item274
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5205,7 +5129,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item284
+		class Item275
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5248,7 +5172,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item285
+		class Item276
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5291,7 +5215,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item286
+		class Item277
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5334,7 +5258,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item287
+		class Item278
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5377,7 +5301,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item288
+		class Item279
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5420,7 +5344,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item289
+		class Item280
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5463,7 +5387,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item290
+		class Item281
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5506,7 +5430,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item291
+		class Item282
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5549,7 +5473,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item292
+		class Item283
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5592,7 +5516,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item293
+		class Item284
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5635,7 +5559,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item294
+		class Item285
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5678,7 +5602,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item295
+		class Item286
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5721,7 +5645,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item296
+		class Item287
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5764,7 +5688,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item297
+		class Item288
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5807,7 +5731,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item298
+		class Item289
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5850,7 +5774,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item299
+		class Item290
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5893,7 +5817,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item300
+		class Item291
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5936,7 +5860,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item301
+		class Item292
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5979,7 +5903,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item302
+		class Item293
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6022,7 +5946,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item303
+		class Item294
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6065,7 +5989,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item304
+		class Item295
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6108,7 +6032,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item305
+		class Item296
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6151,7 +6075,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item306
+		class Item297
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6194,7 +6118,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item307
+		class Item298
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6237,7 +6161,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item308
+		class Item299
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6280,7 +6204,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item309
+		class Item300
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6300,7 +6224,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.07434082;
 		};
-		class Item310
+		class Item301
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6320,7 +6244,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.040130615;
 		};
-		class Item311
+		class Item302
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6338,7 +6262,7 @@ class Mission
 			id=323;
 			type="B_Truck_01_transport_F";
 		};
-		class Item312
+		class Item303
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6381,7 +6305,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item313
+		class Item304
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6422,7 +6346,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item314
+		class Item305
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6464,7 +6388,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item315
+		class Item306
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6505,7 +6429,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item316
+		class Item307
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6546,7 +6470,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item317
+		class Item308
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6588,7 +6512,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item318
+		class Item309
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6630,7 +6554,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item319
+		class Item310
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6672,7 +6596,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item320
+		class Item311
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6714,7 +6638,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item321
+		class Item312
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6757,7 +6681,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item322
+		class Item313
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6775,7 +6699,7 @@ class Mission
 			type="Land_CampingTable_F";
 			atlOffset=4.875;
 		};
-		class Item323
+		class Item314
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6817,7 +6741,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item324
+		class Item315
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6859,7 +6783,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item325
+		class Item316
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6901,7 +6825,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item326
+		class Item317
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6943,7 +6867,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item327
+		class Item318
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6985,7 +6909,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item328
+		class Item319
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7026,7 +6950,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item329
+		class Item320
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7068,7 +6992,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item330
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7110,7 +7034,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item331
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7154,7 +7078,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item332
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7196,7 +7120,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item333
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7238,7 +7162,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item334
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7280,7 +7204,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item335
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7322,7 +7246,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item336
+		class Item327
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7365,7 +7289,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item337
+		class Item328
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7408,7 +7332,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item338
+		class Item329
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7428,7 +7352,7 @@ class Mission
 			id=350;
 			type="B_Heli_Transport_01_camo_F";
 		};
-		class Item339
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7445,7 +7369,7 @@ class Mission
 			id=351;
 			type="Land_HelipadCivil_F";
 		};
-		class Item340
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7463,7 +7387,7 @@ class Mission
 			id=352;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item341
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7482,7 +7406,7 @@ class Mission
 			type="Box_NATO_AmmoVeh_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item342
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7500,7 +7424,7 @@ class Mission
 			id=354;
 			type="RoadCone_F";
 		};
-		class Item343
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7518,7 +7442,7 @@ class Mission
 			id=355;
 			type="RoadCone_F";
 		};
-		class Item344
+		class Item335
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7537,7 +7461,7 @@ class Mission
 			id=357;
 			type="B_MRAP_01_hmg_F";
 		};
-		class Item345
+		class Item336
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7557,7 +7481,7 @@ class Mission
 			id=358;
 			type="Land_HBarrierBig_F";
 		};
-		class Item346
+		class Item337
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7577,7 +7501,7 @@ class Mission
 			id=359;
 			type="Land_HBarrierBig_F";
 		};
-		class Item347
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7597,7 +7521,7 @@ class Mission
 			id=360;
 			type="Land_HBarrierBig_F";
 		};
-		class Item348
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7617,7 +7541,7 @@ class Mission
 			id=361;
 			type="Land_HBarrierBig_F";
 		};
-		class Item349
+		class Item340
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7637,7 +7561,7 @@ class Mission
 			id=362;
 			type="Land_HBarrierBig_F";
 		};
-		class Item350
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7657,7 +7581,7 @@ class Mission
 			id=363;
 			type="Land_HBarrierBig_F";
 		};
-		class Item351
+		class Item342
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7678,7 +7602,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=0.00016021729;
 		};
-		class Item352
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7699,7 +7623,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=0.00012397766;
 		};
-		class Item353
+		class Item344
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7717,7 +7641,7 @@ class Mission
 			type="B_APC_Tracked_01_rcws_F";
 			atlOffset=0.5;
 		};
-		class Item354
+		class Item345
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7734,7 +7658,7 @@ class Mission
 			type="C_Boat_Civil_01_rescue_F";
 			atlOffset=4.2356467;
 		};
-		class Item355
+		class Item346
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7753,7 +7677,7 @@ class Mission
 			type="I_Plane_Fighter_03_AA_F";
 			atlOffset=0.25;
 		};
-		class Item356
+		class Item347
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7794,7 +7718,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item357
+		class Item348
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7838,7 +7762,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item358
+		class Item349
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7857,7 +7781,7 @@ class Mission
 			type="Land_PortableLongRangeRadio_F";
 			atlOffset=0.0065002441;
 		};
-		class Item359
+		class Item350
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7875,7 +7799,7 @@ class Mission
 			type="Land_CargoBox_V1_F";
 			atlOffset=186.0253;
 		};
-		class Item360
+		class Item351
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7893,7 +7817,7 @@ class Mission
 			type="Box_East_AmmoVeh_F";
 			atlOffset=185.99831;
 		};
-		class Item361
+		class Item352
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7911,7 +7835,7 @@ class Mission
 			type="Land_Laptop_device_F";
 			atlOffset=185.99432;
 		};
-		class Item362
+		class Item353
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7929,7 +7853,7 @@ class Mission
 			type="Land_Laptop_F";
 			atlOffset=185.98134;
 		};
-		class Item363
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7947,7 +7871,7 @@ class Mission
 			type="Box_NATO_AmmoOrd_F";
 			atlOffset=186.019;
 		};
-		class Item364
+		class Item355
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7965,7 +7889,7 @@ class Mission
 			type="Land_CampingTable_small_F";
 			atlOffset=186.00493;
 		};
-		class Item365
+		class Item356
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7984,7 +7908,7 @@ class Mission
 			type="Box_IND_WpsLaunch_F";
 			atlOffset=185.96758;
 		};
-		class Item366
+		class Item357
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8003,7 +7927,7 @@ class Mission
 			type="Box_IND_WpsSpecial_F";
 			atlOffset=185.98265;
 		};
-		class Item367
+		class Item358
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8047,7 +7971,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item368
+		class Item359
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8065,7 +7989,7 @@ class Mission
 			type="Box_NATO_AmmoOrd_F";
 			atlOffset=186.01076;
 		};
-		class Item369
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8108,7 +8032,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item370
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8151,7 +8075,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item371
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8194,7 +8118,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item372
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8237,7 +8161,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item373
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8280,7 +8204,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item374
+		class Item365
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8323,7 +8247,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item375
+		class Item366
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8366,7 +8290,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item376
+		class Item367
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8409,7 +8333,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item377
+		class Item368
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8452,7 +8376,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item378
+		class Item369
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8495,7 +8419,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item379
+		class Item370
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8538,7 +8462,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item380
+		class Item371
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8581,7 +8505,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item381
+		class Item372
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8599,7 +8523,7 @@ class Mission
 			id=396;
 			type="B_MRAP_01_hmg_F";
 		};
-		class Item382
+		class Item373
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8617,7 +8541,7 @@ class Mission
 			id=397;
 			type="I_APC_tracked_03_cannon_F";
 		};
-		class Item383
+		class Item374
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8636,7 +8560,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=0.25;
 		};
-		class Item384
+		class Item375
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8655,7 +8579,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=0.25;
 		};
-		class Item385
+		class Item376
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8674,7 +8598,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=0.25;
 		};
-		class Item386
+		class Item377
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8718,7 +8642,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item387
+		class Item378
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8762,7 +8686,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item388
+		class Item379
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8805,7 +8729,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item389
+		class Item380
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8848,7 +8772,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item390
+		class Item381
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8891,7 +8815,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item391
+		class Item382
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8934,7 +8858,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item392
+		class Item383
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8977,7 +8901,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item393
+		class Item384
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9020,7 +8944,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item394
+		class Item385
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9064,7 +8988,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item395
+		class Item386
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9108,7 +9032,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item396
+		class Item387
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9152,7 +9076,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item397
+		class Item388
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9169,7 +9093,7 @@ class Mission
 			id=412;
 			type="C_Kart_01_Blu_F";
 		};
-		class Item398
+		class Item389
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9186,7 +9110,7 @@ class Mission
 			id=413;
 			type="C_Kart_01_Fuel_F";
 		};
-		class Item399
+		class Item390
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9203,7 +9127,7 @@ class Mission
 			id=414;
 			type="C_Kart_01_F";
 		};
-		class Item400
+		class Item391
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9220,7 +9144,7 @@ class Mission
 			id=415;
 			type="C_Kart_01_Vrana_F";
 		};
-		class Item401
+		class Item392
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9261,7 +9185,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item402
+		class Item393
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9322,7 +9246,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item403
+		class Item394
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9383,7 +9307,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item404
+		class Item395
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9444,7 +9368,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item405
+		class Item396
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9505,7 +9429,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item406
+		class Item397
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9523,7 +9447,7 @@ class Mission
 			id=421;
 			type="B_supplyCrate_F";
 		};
-		class Item407
+		class Item398
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9541,7 +9465,7 @@ class Mission
 			id=422;
 			type="B_supplyCrate_F";
 		};
-		class Item408
+		class Item399
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9559,7 +9483,7 @@ class Mission
 			id=423;
 			type="B_supplyCrate_F";
 		};
-		class Item409
+		class Item400
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9577,7 +9501,7 @@ class Mission
 			id=424;
 			type="B_supplyCrate_F";
 		};
-		class Item410
+		class Item401
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9595,7 +9519,7 @@ class Mission
 			id=425;
 			type="B_Truck_01_covered_F";
 		};
-		class Item411
+		class Item402
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9616,7 +9540,7 @@ class Mission
 			id=426;
 			type="B_Heli_Light_01_armed_F";
 		};
-		class Item412
+		class Item403
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9633,7 +9557,7 @@ class Mission
 			id=427;
 			type="Land_HelipadCivil_F";
 		};
-		class Item413
+		class Item404
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9651,7 +9575,7 @@ class Mission
 			id=428;
 			type="RoadCone_F";
 		};
-		class Item414
+		class Item405
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9669,7 +9593,7 @@ class Mission
 			id=429;
 			type="RoadCone_F";
 		};
-		class Item415
+		class Item406
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9687,7 +9611,7 @@ class Mission
 			id=430;
 			type="RoadCone_F";
 		};
-		class Item416
+		class Item407
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9705,7 +9629,7 @@ class Mission
 			id=431;
 			type="RoadCone_F";
 		};
-		class Item417
+		class Item408
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9723,7 +9647,7 @@ class Mission
 			id=432;
 			type="RoadCone_F";
 		};
-		class Item418
+		class Item409
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9741,7 +9665,7 @@ class Mission
 			id=433;
 			type="RoadCone_F";
 		};
-		class Item419
+		class Item410
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9759,7 +9683,7 @@ class Mission
 			id=434;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item420
+		class Item411
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9777,7 +9701,7 @@ class Mission
 			id=435;
 			type="RoadCone_F";
 		};
-		class Item421
+		class Item412
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9795,7 +9719,7 @@ class Mission
 			id=436;
 			type="RoadCone_F";
 		};
-		class Item422
+		class Item413
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9813,7 +9737,7 @@ class Mission
 			id=437;
 			type="RoadCone_F";
 		};
-		class Item423
+		class Item414
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9831,7 +9755,7 @@ class Mission
 			id=438;
 			type="RoadCone_F";
 		};
-		class Item424
+		class Item415
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9849,7 +9773,7 @@ class Mission
 			id=439;
 			type="RoadCone_F";
 		};
-		class Item425
+		class Item416
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9867,7 +9791,7 @@ class Mission
 			id=440;
 			type="RoadCone_F";
 		};
-		class Item426
+		class Item417
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9885,7 +9809,7 @@ class Mission
 			id=441;
 			type="RoadCone_F";
 		};
-		class Item427
+		class Item418
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9903,7 +9827,7 @@ class Mission
 			id=442;
 			type="RoadCone_F";
 		};
-		class Item428
+		class Item419
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9921,7 +9845,7 @@ class Mission
 			id=443;
 			type="RoadCone_F";
 		};
-		class Item429
+		class Item420
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9939,7 +9863,7 @@ class Mission
 			id=444;
 			type="RoadCone_F";
 		};
-		class Item430
+		class Item421
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9958,7 +9882,7 @@ class Mission
 			type="RoadCone_F";
 			atlOffset=-2.6702881e-005;
 		};
-		class Item431
+		class Item422
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9976,7 +9900,7 @@ class Mission
 			id=446;
 			type="RoadCone_F";
 		};
-		class Item432
+		class Item423
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9994,7 +9918,7 @@ class Mission
 			id=447;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item433
+		class Item424
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10012,7 +9936,7 @@ class Mission
 			id=448;
 			type="RoadCone_F";
 		};
-		class Item434
+		class Item425
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10030,7 +9954,7 @@ class Mission
 			id=449;
 			type="RoadCone_F";
 		};
-		class Item435
+		class Item426
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10048,7 +9972,7 @@ class Mission
 			id=450;
 			type="RoadCone_F";
 		};
-		class Item436
+		class Item427
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10067,7 +9991,7 @@ class Mission
 			type="RoadCone_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item437
+		class Item428
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10085,7 +10009,7 @@ class Mission
 			id=452;
 			type="RoadCone_F";
 		};
-		class Item438
+		class Item429
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10103,7 +10027,7 @@ class Mission
 			id=453;
 			type="RoadCone_F";
 		};
-		class Item439
+		class Item430
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10121,7 +10045,7 @@ class Mission
 			id=454;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item440
+		class Item431
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10139,7 +10063,7 @@ class Mission
 			id=455;
 			type="RoadCone_F";
 		};
-		class Item441
+		class Item432
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10157,7 +10081,7 @@ class Mission
 			id=456;
 			type="RoadCone_F";
 		};
-		class Item442
+		class Item433
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10176,7 +10100,7 @@ class Mission
 			type="RoadCone_F";
 			atlOffset=0.086330414;
 		};
-		class Item443
+		class Item434
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10194,7 +10118,7 @@ class Mission
 			id=458;
 			type="RoadCone_F";
 		};
-		class Item444
+		class Item435
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10212,7 +10136,7 @@ class Mission
 			id=459;
 			type="RoadCone_F";
 		};
-		class Item445
+		class Item436
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10230,7 +10154,7 @@ class Mission
 			id=460;
 			type="RoadCone_F";
 		};
-		class Item446
+		class Item437
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10248,7 +10172,7 @@ class Mission
 			id=461;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item447
+		class Item438
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10266,7 +10190,7 @@ class Mission
 			id=462;
 			type="RoadCone_F";
 		};
-		class Item448
+		class Item439
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10284,7 +10208,7 @@ class Mission
 			id=463;
 			type="RoadCone_F";
 		};
-		class Item449
+		class Item440
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10302,7 +10226,7 @@ class Mission
 			id=464;
 			type="RoadCone_F";
 		};
-		class Item450
+		class Item441
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10320,7 +10244,7 @@ class Mission
 			id=465;
 			type="RoadCone_F";
 		};
-		class Item451
+		class Item442
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10338,7 +10262,7 @@ class Mission
 			id=466;
 			type="RoadCone_F";
 		};
-		class Item452
+		class Item443
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10356,7 +10280,7 @@ class Mission
 			id=467;
 			type="RoadCone_F";
 		};
-		class Item453
+		class Item444
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10374,7 +10298,7 @@ class Mission
 			id=468;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item454
+		class Item445
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10392,7 +10316,7 @@ class Mission
 			id=469;
 			type="RoadCone_F";
 		};
-		class Item455
+		class Item446
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10410,7 +10334,7 @@ class Mission
 			id=470;
 			type="RoadCone_F";
 		};
-		class Item456
+		class Item447
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10428,7 +10352,7 @@ class Mission
 			id=471;
 			type="RoadCone_F";
 		};
-		class Item457
+		class Item448
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10446,7 +10370,7 @@ class Mission
 			id=472;
 			type="RoadCone_F";
 		};
-		class Item458
+		class Item449
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10464,7 +10388,7 @@ class Mission
 			id=473;
 			type="RoadCone_F";
 		};
-		class Item459
+		class Item450
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10482,7 +10406,7 @@ class Mission
 			id=474;
 			type="RoadCone_F";
 		};
-		class Item460
+		class Item451
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10500,7 +10424,7 @@ class Mission
 			id=475;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item461
+		class Item452
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10518,7 +10442,7 @@ class Mission
 			id=476;
 			type="RoadCone_F";
 		};
-		class Item462
+		class Item453
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10536,7 +10460,7 @@ class Mission
 			id=477;
 			type="RoadCone_F";
 		};
-		class Item463
+		class Item454
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10554,7 +10478,7 @@ class Mission
 			id=478;
 			type="RoadCone_F";
 		};
-		class Item464
+		class Item455
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10572,7 +10496,7 @@ class Mission
 			id=479;
 			type="RoadCone_F";
 		};
-		class Item465
+		class Item456
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10590,7 +10514,7 @@ class Mission
 			id=480;
 			type="RoadCone_F";
 		};
-		class Item466
+		class Item457
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10608,7 +10532,7 @@ class Mission
 			id=481;
 			type="RoadCone_F";
 		};
-		class Item467
+		class Item458
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10626,7 +10550,7 @@ class Mission
 			id=482;
 			type="Box_NATO_AmmoVeh_F";
 		};
-		class Item468
+		class Item459
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10644,7 +10568,7 @@ class Mission
 			id=483;
 			type="B_APC_Tracked_01_CRV_F";
 		};
-		class Item469
+		class Item460
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10661,7 +10585,7 @@ class Mission
 			id=484;
 			type="Land_HelipadSquare_F";
 		};
-		class Item470
+		class Item461
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10678,7 +10602,7 @@ class Mission
 			id=485;
 			type="RoadCone_F";
 		};
-		class Item471
+		class Item462
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10695,7 +10619,7 @@ class Mission
 			id=486;
 			type="RoadCone_F";
 		};
-		class Item472
+		class Item463
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10712,7 +10636,7 @@ class Mission
 			id=487;
 			type="RoadCone_F";
 		};
-		class Item473
+		class Item464
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10729,7 +10653,7 @@ class Mission
 			id=488;
 			type="RoadCone_F";
 		};
-		class Item474
+		class Item465
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10746,7 +10670,7 @@ class Mission
 			id=489;
 			type="Land_HelipadSquare_F";
 		};
-		class Item475
+		class Item466
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10763,7 +10687,7 @@ class Mission
 			id=490;
 			type="RoadCone_F";
 		};
-		class Item476
+		class Item467
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10780,7 +10704,7 @@ class Mission
 			id=491;
 			type="RoadCone_F";
 		};
-		class Item477
+		class Item468
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10797,7 +10721,7 @@ class Mission
 			id=492;
 			type="RoadCone_F";
 		};
-		class Item478
+		class Item469
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10814,7 +10738,7 @@ class Mission
 			id=493;
 			type="RoadCone_F";
 		};
-		class Item479
+		class Item470
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10831,7 +10755,7 @@ class Mission
 			id=494;
 			type="Land_HelipadSquare_F";
 		};
-		class Item480
+		class Item471
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10848,7 +10772,7 @@ class Mission
 			id=495;
 			type="RoadCone_F";
 		};
-		class Item481
+		class Item472
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10865,7 +10789,7 @@ class Mission
 			id=496;
 			type="RoadCone_F";
 		};
-		class Item482
+		class Item473
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10882,7 +10806,7 @@ class Mission
 			id=497;
 			type="RoadCone_F";
 		};
-		class Item483
+		class Item474
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10899,7 +10823,7 @@ class Mission
 			id=498;
 			type="RoadCone_F";
 		};
-		class Item484
+		class Item475
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10917,7 +10841,7 @@ class Mission
 			id=499;
 			type="B_Slingload_01_Repair_F";
 		};
-		class Item485
+		class Item476
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10935,7 +10859,7 @@ class Mission
 			id=500;
 			type="B_Slingload_01_Fuel_F";
 		};
-		class Item486
+		class Item477
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10953,7 +10877,7 @@ class Mission
 			id=501;
 			type="B_Slingload_01_Ammo_F";
 		};
-		class Item487
+		class Item478
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10972,7 +10896,7 @@ class Mission
 			id=502;
 			type="B_Slingload_01_Medevac_F";
 		};
-		class Item488
+		class Item479
 		{
 			dataType="Group";
 			side="West";
@@ -11162,7 +11086,7 @@ class Mission
 			};
 			id=503;
 		};
-		class Item489
+		class Item480
 		{
 			dataType="Group";
 			side="West";
@@ -11329,7 +11253,7 @@ class Mission
 			};
 			id=512;
 		};
-		class Item490
+		class Item481
 		{
 			dataType="Group";
 			side="West";
@@ -11496,7 +11420,7 @@ class Mission
 			};
 			id=521;
 		};
-		class Item491
+		class Item482
 		{
 			dataType="Group";
 			side="West";
@@ -11663,7 +11587,7 @@ class Mission
 			};
 			id=530;
 		};
-		class Item492
+		class Item483
 		{
 			dataType="Group";
 			side="West";
@@ -11830,7 +11754,7 @@ class Mission
 			};
 			id=539;
 		};
-		class Item493
+		class Item484
 		{
 			dataType="Group";
 			side="West";
@@ -11917,7 +11841,7 @@ class Mission
 			};
 			id=548;
 		};
-		class Item494
+		class Item485
 		{
 			dataType="Group";
 			side="West";
@@ -12005,7 +11929,7 @@ class Mission
 			};
 			id=553;
 		};
-		class Item495
+		class Item486
 		{
 			dataType="Group";
 			side="West";
@@ -12095,7 +12019,7 @@ class Mission
 			};
 			id=558;
 		};
-		class Item496
+		class Item487
 		{
 			dataType="Group";
 			side="West";
@@ -12149,7 +12073,7 @@ class Mission
 			};
 			id=563;
 		};
-		class Item497
+		class Item488
 		{
 			dataType="Group";
 			side="West";
@@ -12203,7 +12127,7 @@ class Mission
 			};
 			id=566;
 		};
-		class Item498
+		class Item489
 		{
 			dataType="Group";
 			side="West";
@@ -12435,7 +12359,7 @@ class Mission
 			};
 			id=569;
 		};
-		class Item499
+		class Item490
 		{
 			dataType="Group";
 			side="West";
@@ -12470,7 +12394,7 @@ class Mission
 			};
 			id=574;
 		};
-		class Item500
+		class Item491
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12482,7 +12406,7 @@ class Mission
 			type="Logic";
 			atlOffset=185.98976;
 		};
-		class Item501
+		class Item492
 		{
 			dataType="Group";
 			side="West";
@@ -12560,7 +12484,7 @@ class Mission
 			id=577;
 			atlOffset=0.5;
 		};
-		class Item502
+		class Item493
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12578,7 +12502,7 @@ class Mission
 			type="B_UAV_02_CAS_F";
 			atlOffset=0.5;
 		};
-		class Item503
+		class Item494
 		{
 			dataType="Group";
 			side="West";
@@ -12656,7 +12580,7 @@ class Mission
 			id=581;
 			atlOffset=0.25;
 		};
-		class Item504
+		class Item495
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12676,7 +12600,7 @@ class Mission
 			type="B_UGV_01_rcws_F";
 			atlOffset=0.25;
 		};
-		class Item505
+		class Item496
 		{
 			dataType="Group";
 			side="West";
@@ -12755,7 +12679,7 @@ class Mission
 			id=585;
 			atlOffset=0.69591713;
 		};
-		class Item506
+		class Item497
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12773,7 +12697,7 @@ class Mission
 			type="B_UAV_02_CAS_F";
 			atlOffset=0.69591713;
 		};
-		class Item507
+		class Item498
 		{
 			dataType="Group";
 			side="West";
@@ -12808,7 +12732,7 @@ class Mission
 			id=589;
 			atlOffset=4.9750004;
 		};
-		class Item508
+		class Item499
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13012,7 +12936,7 @@ class Mission
 				nAttributes=10;
 			};
 		};
-		class Item509
+		class Item500
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13217,7 +13141,7 @@ class Mission
 				nAttributes=10;
 			};
 		};
-		class Item510
+		class Item501
 		{
 			dataType="Group";
 			side="West";
@@ -13340,7 +13264,7 @@ class Mission
 			id=593;
 			atlOffset=-0.0020027161;
 		};
-		class Item511
+		class Item502
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13384,7 +13308,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item512
+		class Item503
 		{
 			dataType="Group";
 			side="West";
@@ -13506,7 +13430,7 @@ class Mission
 			id=599;
 			atlOffset=-0.034000397;
 		};
-		class Item513
+		class Item504
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13550,7 +13474,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item514
+		class Item505
 		{
 			dataType="Group";
 			side="West";
@@ -13668,7 +13592,7 @@ class Mission
 			};
 			id=605;
 		};
-		class Item515
+		class Item506
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13711,7 +13635,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item516
+		class Item507
 		{
 			dataType="Group";
 			side="West";
@@ -13833,7 +13757,7 @@ class Mission
 			id=611;
 			atlOffset=-0.0020008087;
 		};
-		class Item517
+		class Item508
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13877,7 +13801,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item518
+		class Item509
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14081,7 +14005,7 @@ class Mission
 				nAttributes=10;
 			};
 		};
-		class Item519
+		class Item510
 		{
 			dataType="Group";
 			side="West";
@@ -14206,7 +14130,7 @@ class Mission
 			id=618;
 			atlOffset=0.5359993;
 		};
-		class Item520
+		class Item511
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14250,7 +14174,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item521
+		class Item512
 		{
 			dataType="Marker";
 			position[]={26988.115,6.4281941e+025,31023.488};
@@ -14261,7 +14185,7 @@ class Mission
 			id=624;
 			atlOffset=6.4281941e+025;
 		};
-		class Item522
+		class Item513
 		{
 			dataType="Marker";
 			position[]={27008.09,-5.5430829e-017,31565.52};
@@ -14272,7 +14196,7 @@ class Mission
 			id=625;
 			atlOffset=185.97;
 		};
-		class Item523
+		class Item514
 		{
 			dataType="Marker";
 			position[]={26999.727,-1.9414597e-017,32038.336};
@@ -14283,7 +14207,7 @@ class Mission
 			id=626;
 			atlOffset=185.97;
 		};
-		class Item524
+		class Item515
 		{
 			dataType="Marker";
 			position[]={14246.822,-7.0014165e-035,14059.483};
@@ -14294,7 +14218,7 @@ class Mission
 			id=627;
 			atlOffset=92.950974;
 		};
-		class Item525
+		class Item516
 		{
 			dataType="Marker";
 			position[]={14420.3,-1.6822974e-028,14438.078};
@@ -14305,7 +14229,7 @@ class Mission
 			id=629;
 			atlOffset=53.937431;
 		};
-		class Item526
+		class Item517
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14324,7 +14248,7 @@ class Mission
 			id=630;
 			type="B_LSV_01_armed_F";
 		};
-		class Item527
+		class Item518
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14345,7 +14269,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item528
+		class Item519
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14366,7 +14290,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item529
+		class Item520
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14387,7 +14311,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item530
+		class Item521
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14408,7 +14332,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=0.010347366;
 		};
-		class Item531
+		class Item522
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14429,7 +14353,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item532
+		class Item523
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14450,7 +14374,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item533
+		class Item524
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14471,7 +14395,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item534
+		class Item525
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14492,7 +14416,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item535
+		class Item526
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14512,7 +14436,7 @@ class Mission
 			id=645;
 			type="Land_HBarrierBig_F";
 		};
-		class Item536
+		class Item527
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14533,7 +14457,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item537
+		class Item528
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14554,7 +14478,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item538
+		class Item529
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14574,7 +14498,7 @@ class Mission
 			id=648;
 			type="Land_HBarrierBig_F";
 		};
-		class Item539
+		class Item530
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14595,7 +14519,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=0.0069961548;
 		};
-		class Item540
+		class Item531
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14616,7 +14540,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item541
+		class Item532
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14636,7 +14560,7 @@ class Mission
 			id=651;
 			type="Land_HBarrierBig_F";
 		};
-		class Item542
+		class Item533
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14656,7 +14580,7 @@ class Mission
 			id=652;
 			type="Land_HBarrierBig_F";
 		};
-		class Item543
+		class Item534
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14699,7 +14623,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item544
+		class Item535
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14719,7 +14643,7 @@ class Mission
 			type="Land_HBarrierBig_F";
 			atlOffset=0.024002075;
 		};
-		class Item545
+		class Item536
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14762,7 +14686,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item546
+		class Item537
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14805,7 +14729,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item547
+		class Item538
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14848,7 +14772,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item548
+		class Item539
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14891,7 +14815,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item549
+		class Item540
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14933,7 +14857,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item550
+		class Item541
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14977,7 +14901,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item551
+		class Item542
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15019,7 +14943,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item552
+		class Item543
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15061,7 +14985,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item553
+		class Item544
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15104,7 +15028,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item554
+		class Item545
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15146,6 +15070,154 @@ class Mission
 				};
 				nAttributes=1;
 			};
+		};
+		class Item546
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={23349.424,16.205482,19787.916};
+				angles[]={0,2.4090559,0};
+			};
+			side="Empty";
+			class Attributes
+			{
+				skill=0.60000002;
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
+			};
+			id=681;
+			type="B_MBT_01_TUSK_F";
+			atlOffset=0.49668026;
+		};
+		class Item547
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={19975.656,62.768078,11414.811};
+				angles[]={0,0.85494536,0};
+			};
+			side="Empty";
+			class Attributes
+			{
+				skill=0.60000002;
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
+			};
+			id=682;
+			type="B_MBT_01_TUSK_F";
+			atlOffset=0.50817108;
+		};
+		class Item548
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={7254.4536,8.762928,11098.863};
+				angles[]={0,4.7363486,0};
+			};
+			side="Empty";
+			class Attributes
+			{
+				skill=0.60000002;
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
+			};
+			id=683;
+			type="B_MBT_01_TUSK_F";
+			atlOffset=0.52832651;
+		};
+		class Item549
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5763.9741,225.4579,20055.973};
+				angles[]={0,5.1055498,0};
+			};
+			side="Empty";
+			class Attributes
+			{
+				skill=0.60000002;
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
+			};
+			id=684;
+			type="B_MBT_01_TUSK_F";
+			atlOffset=0.51972961;
+		};
+		class Item550
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={4994.7417,20.815624,14412.07};
+				angles[]={0,4.5543618,0};
+			};
+			side="Empty";
+			class Attributes
+			{
+				skill=0.60000002;
+				lock="UNLOCKED";
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
+			};
+			id=685;
+			type="B_APC_Wheeled_01_cannon_F";
+			atlOffset=0.52040672;
+		};
+		class Item551
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={11575.873,26.587866,11991.465};
+				angles[]={0,2.1085713,0};
+			};
+			side="Empty";
+			class Attributes
+			{
+				skill=0.60000002;
+				lock="UNLOCKED";
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
+			};
+			id=686;
+			type="B_APC_Wheeled_01_cannon_F";
+			atlOffset=0.49966621;
+		};
+		class Item552
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={21217.711,26.798161,7091.6787};
+				angles[]={0,5.3440475,0};
+			};
+			side="Empty";
+			class Attributes
+			{
+				skill=0.60000002;
+				lock="UNLOCKED";
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
+			};
+			id=687;
+			type="B_APC_Wheeled_01_cannon_F";
+			atlOffset=0.4792347;
+		};
+		class Item553
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={26735.828,24.134186,24582.428};
+				angles[]={0,3.880666,0};
+			};
+			side="Empty";
+			class Attributes
+			{
+				skill=0.60000002;
+				lock="UNLOCKED";
+				init="_nil = [this, 30, 480] execVM ""veh_respawn.sqf""";
+			};
+			id=688;
+			type="B_APC_Wheeled_01_cannon_F";
+			atlOffset=0.48258209;
 		};
 	};
 	class Connections


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added 4 Slammer UP and 4 Marshall vehicles to Vehicle Service points around the map. 
Reduced respawn delay of heavy vehicles from 480 to 30.
Renamed markers at points with vehicles to Vehicle Depot.
Fixed rotation of markers.
Deleted redundant copies of AO empty markers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Driving tanks and APCs to AOs is very time consuming, and non-rewarding when a new AO spawns on the other side of the map. With predeployed vehicles, crews can be flown out to them, and then only need to drive <5km to any AO.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have tested this in an MP environment.
- [ ] I have tested this in a SP environment.
