### PR TITLE
Fix error where vehicles show 'scalar NaN' on their weapon heading

### DIFF
--- a/public/co61_AW_I&A_TFTEdit.Altis/scripts/vehicle/crew/crew.sqf
+++ b/public/co61_AW_I&A_TFTEdit.Altis/scripts/vehicle/crew/crew.sqf
@@ -10,8 +10,6 @@ while { true } do  {
     if(player != vehicle player) then {
         _name = "";
         _vehicle = assignedVehicle player;
-        _weapname = getarray (configFile >> "CfgVehicles" >> typeOf (vehicle player) >> "Turrets" >> "MainTurret" >> "weapons"); 
-        _weap = _weapname select 0;
         {
             if((driver _vehicle == _x) || (gunner _vehicle == _x)) then {
                 if(driver _vehicle == _x) then {
@@ -20,7 +18,7 @@ while { true } do  {
                     _target = cursorTarget;
                     _picture = getText (configFile >> "cfgVehicles" >> typeOf _target >> "displayname");
                     _vehtarget =  format ["%1",_picture];
-                    _wepdir =  (vehicle player) weaponDirection _weap;
+                    _wepdir =  (vehicle player) weaponDirection currentWeapon (vehicle player);
                     _Azimuth = round  (((_wepdir select 0) ) atan2 ((_wepdir select 1) ) + 360) % 360;
                     _name = format ["<t size='0.85' color='#f0e68c'>%1 %2</t> <img size='0.7' color='#6b8e23' image='a3\ui_f\data\IGUI\Cfg\Actions\getingunner_ca.paa'/><br/> <t size='0.85' color='#f0e68c'>Heading :<t/> <t size='0.85' color='#ff0000'>%3</t><br/><t size='0.85' color='#f0e68c'> Target : </t><t size='0.85' color='#ff0000'>%4</t><br/>", _name, (name _x), _Azimuth, _vehtarget];
                 };


### PR DESCRIPTION
Instead of pulling turret from the config, just get `currentWeapon` of the players' vehicle.

## Motivation and Context
Script errored out when vehicle didn't have weapons on their main turret.

## How Has This Been Tested?
Tested in multiple vehicles by getting into them and checking if moving turret changes the output value.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] I have tested this in an MP environment.
- [x ] I have tested this in a SP environment.
